### PR TITLE
Change invincibility to timer based and fix collision bug

### DIFF
--- a/src/Scenes/BadGuys/Snowball.gd
+++ b/src/Scenes/BadGuys/Snowball.gd
@@ -67,6 +67,11 @@ func _on_Head_area_entered(area):
 
 # Hit player
 func _on_snowball_body_entered(body):
-	if state == "active" and body.has_method("hurt") and body.invincible_time == 0:
+	if state == "active" and body.has_method("hurt") and body.invincible == false:
 		body.hurt()
+		$ResetCollisionTimer.start()
 	return
+
+func _on_ResetCollisionTimer_timeout():
+	$Area2D/CollisionShape2D.disabled = true
+	$Area2D/CollisionShape2D.disabled = false

--- a/src/Scenes/BadGuys/Snowball.tscn
+++ b/src/Scenes/BadGuys/Snowball.tscn
@@ -163,7 +163,7 @@ script = ExtResource( 1 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )
-frame = 2
+frame = 7
 playing = true
 offset = Vector2( 0, -3 )
 
@@ -191,6 +191,7 @@ anims/melting = SubResource( 6 )
 anims/squished = SubResource( 7 )
 
 [node name="SFX" type="Node" parent="."]
+editor/display_folded = true
 
 [node name="Fall" type="AudioStreamPlayer2D" parent="SFX"]
 stream = ExtResource( 16 )
@@ -203,5 +204,9 @@ attenuation = 0.25
 [node name="Melt" type="AudioStreamPlayer2D" parent="SFX"]
 stream = ExtResource( 18 )
 attenuation = 0.25
+
+[node name="ResetCollisionTimer" type="Timer" parent="."]
+wait_time = 4.1
 [connection signal="area_entered" from="Head" to="." method="_on_Head_area_entered"]
 [connection signal="body_entered" from="Area2D" to="." method="_on_snowball_body_entered"]
+[connection signal="timeout" from="ResetCollisionTimer" to="." method="_on_ResetCollisionTimer_timeout"]

--- a/src/Scenes/Player/Player.gd
+++ b/src/Scenes/Player/Player.gd
@@ -34,8 +34,9 @@ const GRAVITY = 20.0
 # Amount of frames Tux can still jump after falling off a ledge
 const LEDGE_JUMP = 3
 
-# Invincible time after being hit
-const SAFE_TIME = 108
+# Invincible state
+var invincible = false
+var damageinvincible = false
 # Fireball speed
 const FIREBALL_SPEED = 500
 
@@ -49,7 +50,6 @@ var ducking = false # Ducking
 var backflip = false # Backflipping
 var backflip_rotation = 0 # Backflip rotation
 var state = "fire" # Tux's power-up state
-var invincible_time = 0 # Amount of frames Tux is invincible
 var camera_offset = 0 # Moves camera horizontally for extended view
 var dead = false # Stop doing stuff if true
 
@@ -65,11 +65,15 @@ func hurt():
 	elif state == "big":
 		state = "small"
 		$SFX/Hurt.play()
-		invincible_time = SAFE_TIME
+		invincible = true
+		damageinvincible = true
+		$DamageInvincibilityTimer.start()
 	else:
 		state = "big"
 		$SFX/Hurt.play()
-		invincible_time = SAFE_TIME
+		invincible = true
+		damageinvincible = true
+		$DamageInvincibilityTimer.start()
 
 # Kill Tux
 func kill():
@@ -252,15 +256,13 @@ func _physics_process(delta):
 		$BigHitbox.disabled = false
 		$SmallHitbox.disabled = true
 
-	# Invincible flashing
-	if invincible_time > 0:
+	# Damage Invincible flashing
+	if damageinvincible == true:
 		if $AnimatedSprite.visible == true:
 			$AnimatedSprite.visible = false
 		else: $AnimatedSprite.visible = true
-		invincible_time -= 1
 	else:
 		$AnimatedSprite.visible = true
-		invincible_time = 0
 
 	# Shooting
 	if Input.is_action_just_pressed("action") and state == "fire" and get_tree().get_nodes_in_group("bullets").size() < 2:
@@ -297,3 +299,7 @@ func _physics_process(delta):
 		position.x = $Camera2D.limit_right - 16
 	if position.y > $Camera2D.limit_bottom:
 		kill()
+
+func _on_DamageInvincibilityTimer_timeout():
+	invincible = false
+	damageinvincible = false

--- a/src/Scenes/Player/Player.tscn
+++ b/src/Scenes/Player/Player.tscn
@@ -2,31 +2,31 @@
 
 [ext_resource path="res://Scenes/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Creatures/Tux/Big/Stand.png" type="Texture" id=2]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/duck-0.png" type="Texture" id=3]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/skid-0.png" type="Texture" id=4]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk8.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk1.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk2.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk3.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk4.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk5.png" type="Texture" id=10]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk6.png" type="Texture" id=11]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk7.png" type="Texture" id=12]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/jump-0.png" type="Texture" id=13]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk8.png" type="Texture" id=14]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk1.png" type="Texture" id=15]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk2.png" type="Texture" id=16]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk3.png" type="Texture" id=17]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk4.png" type="Texture" id=18]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk5.png" type="Texture" id=19]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk6.png" type="Texture" id=20]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk7.png" type="Texture" id=21]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/stand-0.png" type="Texture" id=22]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/gameover-0.png" type="Texture" id=23]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/gameover-1.png" type="Texture" id=24]
-[ext_resource path="res://Sprites/Creatures/Tux/Small/jump-0.png" type="Texture" id=25]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/skid-0.png" type="Texture" id=26]
-[ext_resource path="res://Sprites/Creatures/Tux/Big/backflip.png" type="Texture" id=27]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/skid-0.png" type="Texture" id=3]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/backflip.png" type="Texture" id=4]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/duck-0.png" type="Texture" id=5]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/jump-0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/gameover-0.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/gameover-1.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/skid-0.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/jump-0.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/stand-0.png" type="Texture" id=11]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk8.png" type="Texture" id=12]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk1.png" type="Texture" id=13]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk2.png" type="Texture" id=14]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk3.png" type="Texture" id=15]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk4.png" type="Texture" id=16]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk5.png" type="Texture" id=17]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk6.png" type="Texture" id=18]
+[ext_resource path="res://Sprites/Creatures/Tux/Small/Smalltuxwalk7.png" type="Texture" id=19]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk8.png" type="Texture" id=20]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk1.png" type="Texture" id=21]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk2.png" type="Texture" id=22]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk3.png" type="Texture" id=23]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk4.png" type="Texture" id=24]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk5.png" type="Texture" id=25]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk6.png" type="Texture" id=26]
+[ext_resource path="res://Sprites/Creatures/Tux/Big/Bigtuxwalk7.png" type="Texture" id=27]
 [ext_resource path="res://Audio/SoundEffects/jump.wav" type="AudioStream" id=28]
 [ext_resource path="res://Audio/SoundEffects/bigjump.wav" type="AudioStream" id=29]
 [ext_resource path="res://Audio/SoundEffects/flip.wav" type="AudioStream" id=30]
@@ -44,58 +44,58 @@ animations = [ {
 }, {
 "frames": [ ExtResource( 3 ) ],
 "loop": true,
-"name": "duck",
+"name": "skid",
 "speed": 5.0
 }, {
 "frames": [ ExtResource( 4 ) ],
 "loop": true,
-"name": "skid_small",
+"name": "backflip",
 "speed": 5.0
 }, {
-"frames": [ ExtResource( 5 ), ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ), ExtResource( 11 ), ExtResource( 12 ) ],
+"frames": [ ExtResource( 5 ) ],
 "loop": true,
-"name": "walk",
-"speed": 20.0
-}, {
-"frames": [ ExtResource( 13 ) ],
-"loop": true,
-"name": "jump",
+"name": "duck",
 "speed": 5.0
 }, {
-"frames": [ ExtResource( 14 ), ExtResource( 15 ), ExtResource( 16 ), ExtResource( 17 ), ExtResource( 18 ), ExtResource( 19 ), ExtResource( 20 ), ExtResource( 21 ) ],
-"loop": true,
-"name": "walk_small",
-"speed": 20.0
-}, {
-"frames": [ ExtResource( 22 ) ],
-"loop": true,
-"name": "idle_small",
-"speed": 5.0
-}, {
-"frames": [ ExtResource( 23 ), ExtResource( 24 ) ],
-"loop": true,
-"name": "gameover_small",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 25 ) ],
+"frames": [ ExtResource( 6 ) ],
 "loop": true,
 "name": "jump_small",
 "speed": 5.0
 }, {
-"frames": [ ExtResource( 23 ), ExtResource( 24 ) ],
+"frames": [ ExtResource( 7 ), ExtResource( 8 ) ],
+"loop": true,
+"name": "gameover_small",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 9 ) ],
+"loop": true,
+"name": "skid_small",
+"speed": 5.0
+}, {
+"frames": [ ExtResource( 10 ) ],
+"loop": true,
+"name": "jump",
+"speed": 5.0
+}, {
+"frames": [ ExtResource( 11 ) ],
+"loop": true,
+"name": "idle_small",
+"speed": 5.0
+}, {
+"frames": [ ExtResource( 12 ), ExtResource( 13 ), ExtResource( 14 ), ExtResource( 15 ), ExtResource( 16 ), ExtResource( 17 ), ExtResource( 18 ), ExtResource( 19 ) ],
+"loop": true,
+"name": "walk_small",
+"speed": 20.0
+}, {
+"frames": [ ExtResource( 7 ), ExtResource( 8 ) ],
 "loop": true,
 "name": "gameover",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 26 ) ],
+"frames": [ ExtResource( 20 ), ExtResource( 21 ), ExtResource( 22 ), ExtResource( 23 ), ExtResource( 24 ), ExtResource( 25 ), ExtResource( 26 ), ExtResource( 27 ) ],
 "loop": true,
-"name": "skid",
-"speed": 5.0
-}, {
-"frames": [ ExtResource( 27 ) ],
-"loop": true,
-"name": "backflip",
-"speed": 5.0
+"name": "walk",
+"speed": 20.0
 } ]
 
 [sub_resource type="RectangleShape2D" id=2]
@@ -144,6 +144,7 @@ smoothing_speed = 0.0
 editor_draw_drag_margin = true
 
 [node name="SFX" type="Node" parent="."]
+editor/display_folded = true
 
 [node name="Jump" type="AudioStreamPlayer" parent="SFX"]
 stream = ExtResource( 28 )
@@ -169,7 +170,12 @@ stream = ExtResource( 34 )
 [node name="SquishRadius" type="Area2D" parent="." groups=[
 "bottom",
 ]]
+editor/display_folded = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="SquishRadius"]
 position = Vector2( 0, 37 )
 shape = SubResource( 4 )
+
+[node name="DamageInvincibilityTimer" type="Timer" parent="."]
+wait_time = 4.0
+[connection signal="timeout" from="DamageInvincibilityTimer" to="." method="_on_DamageInvincibilityTimer_timeout"]


### PR DESCRIPTION
The damage invincibility time is now timer based. You can change how long invincibility lasts by changing the Wait Time setting in the timer node. I also added a variable so the player only flashes if they got invincibility from being damaged. This makes it easier to add the invincibility star later.

Also the snowball collision issue should be fixed. Now .1 seconds after the player invincibility ends the collision box for snowballs turns off then on again. If the player is inside the snowball they should get damaged now.