### PR TITLE
Organize level editor scene and code

### DIFF
--- a/src/Scenes/UI/LevelEditor.gd
+++ b/src/Scenes/UI/LevelEditor.gd
@@ -1,7 +1,6 @@
 extends Node2D
 
 const CAMERA_MOVE_SPEED = 32
-var category_selected = "Tiles"
 var tilemap_selected = "TileMap"
 var tile_type = 0
 var tile_selected = Vector2(0,0)
@@ -23,11 +22,6 @@ func _process(delta):
 	$Grid.rect_position = Vector2(get_tree().current_scene.get_node("Camera2D").position.x - (get_viewport().size.x / 2), get_tree().current_scene.get_node("Camera2D").position.y - (get_viewport().size.y / 2))
 	$Grid.rect_position = Vector2(floor($Grid.rect_position.x / 32) * 32, floor($Grid.rect_position.y / 32) * 32)
 	$Grid.visible = true
-	$UI/SideBar/SideBar.margin_bottom = get_viewport().size.y
-	$UI/BottomBar/BottomBar.margin_right = get_viewport().size.x - 128 + sidebar_offset
-	$UI/SideBar.rect_position.x = get_viewport().size.x + sidebar_offset
-	$UI/SideBarOverlay.rect_position.x = get_viewport().size.x + sidebar_offset
-	$UI/BottomBar.rect_position.y = get_viewport().size.y + (bottombar_offset * 0.5)
 	$Grid.self_modulate = Color(1, 1, 1, 1 - (sidebar_offset / 128))
 	
 	if get_tree().current_scene.editmode == false:
@@ -51,21 +45,12 @@ func _process(delta):
 			bottombar_offset *= 0.8
 		$UI.offset = Vector2(0,0)
 	
-	if $UI/TilesButton.pressed == true:
-		category_selected = "Tiles"
 	
-	if $UI/ObjectsButton.pressed == true:
-		category_selected = "Objects"
 	
-	if category_selected == "Tiles":
-		$UI/SideBarOverlay/TilesSelected.visible = true
-		$UI/SideBarOverlay/ObjectsSelected.visible = false
-	else:
-		$UI/SideBarOverlay/TilesSelected.visible = false
-		$UI/SideBarOverlay/ObjectsSelected.visible = true
+
+func _input(event):
 	
 	tile_selected = get_tree().current_scene.get_node(str("Level/", tilemap_selected)).world_to_map(get_global_mouse_position())
-	
 	update_selected_tile()
 	
 	if Input.is_action_pressed("click_left"):
@@ -87,10 +72,8 @@ func _process(delta):
 	if Input.is_action_pressed("ui_left"):
 		get_tree().current_scene.get_node("Camera2D").position.x -= CAMERA_MOVE_SPEED
 		
-	if Input.is_action_pressed("ui_down"):
+	if Input.is_action_pressed("ui_right"):
 		get_tree().current_scene.get_node("Camera2D").position.x += CAMERA_MOVE_SPEED
-		
-
 
 func update_selected_tile():
 	$SelectedTile.visible = false
@@ -101,3 +84,9 @@ func update_selected_tile():
 		$SelectedTile.region_rect.position = get_tree().current_scene.get_node(str("Level/", tilemap_selected)).get_tileset().autotile_get_icon_coordinate(tile_type) * get_tree().current_scene.get_node(str("Level/", tilemap_selected)).cell_size
 		$SelectedTile.position.x = (tile_selected.x + 0.5) * get_tree().current_scene.get_node(str("Level/", tilemap_selected)).cell_size.x
 		$SelectedTile.position.y = (tile_selected.y + 0.5) * get_tree().current_scene.get_node(str("Level/", tilemap_selected)).cell_size.y
+
+func _on_TilesButton_pressed():
+	pass
+
+func _on_ObjectsButton_pressed():
+	pass

--- a/src/Scenes/UI/LevelEditor.tscn
+++ b/src/Scenes/UI/LevelEditor.tscn
@@ -1,18 +1,23 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Scenes/UI/LevelEditor.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Editor/Grid.png" type="Texture" id=2]
-[ext_resource path="res://Sprites/Editor/Line.png" type="Texture" id=3]
-[ext_resource path="res://Fonts/SuperTux-Medium.ttf" type="DynamicFontData" id=4]
-[ext_resource path="res://Sprites/Editor/Arrow.png" type="Texture" id=5]
+[ext_resource path="res://Fonts/SuperTux-Medium.ttf" type="DynamicFontData" id=3]
+[ext_resource path="res://Sprites/Editor/Arrow.png" type="Texture" id=4]
+[ext_resource path="res://Sprites/Editor/Line.png" type="Texture" id=5]
 
-[sub_resource type="DynamicFont" id=1]
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 1, 1, 1, 0 )
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="DynamicFont" id=3]
 size = 18
 outline_size = 1
 outline_color = Color( 0, 0, 0, 1 )
 use_filter = true
-extra_spacing_bottom = 12
-font_data = ExtResource( 4 )
+font_data = ExtResource( 3 )
 
 [node name="Node2D" type="Node2D"]
 script = ExtResource( 1 )
@@ -37,129 +42,99 @@ region_rect = Rect2( 0, 0, 32, 32 )
 [node name="UI" type="CanvasLayer" parent="."]
 layer = 3
 
-[node name="SideBar" type="Control" parent="UI"]
-editor/display_folded = true
+[node name="SideBar" type="ColorRect" parent="UI"]
 anchor_left = 1.0
 anchor_right = 1.0
-mouse_filter = 2
-
-[node name="SideBar" type="ColorRect" parent="UI/SideBar"]
-anchor_left = 1.0
-anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = -128.0
-margin_bottom = 480.0
 color = Color( 1, 1, 1, 0.752941 )
 
-[node name="Line1" type="TextureRect" parent="UI/SideBar"]
-anchor_left = 1.0
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/SideBar"]
 anchor_right = 1.0
-margin_left = -128.0
-margin_top = 32.0
-margin_bottom = 34.0
-texture = ExtResource( 3 )
-
-[node name="Line2" type="TextureRect" parent="UI/SideBar"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_top = 66.0
-margin_bottom = 68.0
-texture = ExtResource( 3 )
-
-[node name="Line3" type="TextureRect" parent="UI/SideBar"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_top = 100.0
-margin_bottom = 102.0
-texture = ExtResource( 3 )
-
-[node name="BottomBar" type="Control" parent="UI"]
-editor/display_folded = true
-anchor_top = 1.0
 anchor_bottom = 1.0
-mouse_filter = 2
+custom_constants/separation = 0
 
-[node name="BottomBar" type="ColorRect" parent="UI/BottomBar"]
+[node name="TilesButton" type="Button" parent="UI/SideBar/VBoxContainer"]
+editor/display_folded = true
+margin_right = 128.0
+margin_bottom = 30.0
+grow_horizontal = 0
+grow_vertical = 0
+rect_min_size = Vector2( 0, 30 )
+size_flags_horizontal = 3
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 1 )
+custom_styles/focus = SubResource( 2 )
+custom_styles/normal = SubResource( 1 )
+custom_fonts/font = SubResource( 3 )
+text = "Tiles"
+
+[node name="Arrow1" type="TextureRect" parent="UI/SideBar/VBoxContainer/TilesButton"]
+anchor_top = 0.5
+anchor_bottom = 0.5
+margin_top = -4.0
+margin_right = 7.0
+margin_bottom = 4.0
+texture = ExtResource( 4 )
+
+[node name="Line1" type="TextureRect" parent="UI/SideBar/VBoxContainer"]
+margin_top = 30.0
+margin_right = 128.0
+margin_bottom = 32.0
+texture = ExtResource( 5 )
+
+[node name="ObjectsButton" type="Button" parent="UI/SideBar/VBoxContainer"]
+editor/display_folded = true
+margin_top = 32.0
+margin_right = 128.0
+margin_bottom = 62.0
+grow_horizontal = 0
+grow_vertical = 0
+rect_min_size = Vector2( 0, 30 )
+size_flags_horizontal = 3
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 1 )
+custom_styles/focus = SubResource( 2 )
+custom_styles/normal = SubResource( 1 )
+custom_fonts/font = SubResource( 3 )
+text = "Objects"
+
+[node name="Arrow2" type="TextureRect" parent="UI/SideBar/VBoxContainer/ObjectsButton"]
+anchor_top = 0.5
+anchor_bottom = 0.5
+margin_top = -4.0
+margin_right = 7.0
+margin_bottom = 4.0
+texture = ExtResource( 4 )
+
+[node name="Line2" type="TextureRect" parent="UI/SideBar/VBoxContainer"]
+margin_top = 62.0
+margin_right = 128.0
+margin_bottom = 64.0
+texture = ExtResource( 5 )
+
+[node name="EraserButton" type="Button" parent="UI/SideBar/VBoxContainer"]
+margin_top = 64.0
+margin_right = 128.0
+margin_bottom = 94.0
+rect_min_size = Vector2( 0, 30 )
+custom_styles/hover = SubResource( 1 )
+custom_styles/pressed = SubResource( 1 )
+custom_styles/focus = SubResource( 2 )
+custom_styles/normal = SubResource( 1 )
+
+[node name="Line3" type="TextureRect" parent="UI/SideBar/VBoxContainer"]
+margin_top = 94.0
+margin_right = 128.0
+margin_bottom = 96.0
+texture = ExtResource( 5 )
+
+[node name="BottomBar" type="ColorRect" parent="UI"]
 anchor_top = 1.0
+anchor_right = 1.0
 anchor_bottom = 1.0
 margin_top = -64.0
-margin_right = 512.0
+margin_right = -128.0
 color = Color( 0.196078, 0.196078, 0.196078, 0.752941 )
-
-[node name="SideBarOverlay" type="Control" parent="UI"]
-anchor_left = 1.0
-anchor_right = 1.0
-mouse_filter = 2
-
-[node name="TilesSelected" type="ColorRect" parent="UI/SideBarOverlay"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_bottom = 32.0
-
-[node name="ObjectsSelected" type="ColorRect" parent="UI/SideBarOverlay"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_top = 34.0
-margin_bottom = 66.0
-
-[node name="Label" type="Label" parent="UI/SideBarOverlay"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -102.0
-margin_top = 8.0
-margin_right = -10.0
-margin_bottom = 69.0
-custom_fonts/font = SubResource( 1 )
-custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
-custom_constants/shadow_offset_x = 2
-custom_constants/shadow_offset_y = 2
-text = "Tiles
-Objects"
-
-[node name="Arrow1" type="TextureRect" parent="UI/SideBarOverlay"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -118.0
-margin_top = 12.0
-margin_right = -111.0
-margin_bottom = 20.0
-texture = ExtResource( 5 )
-
-[node name="Arrow2" type="TextureRect" parent="UI/SideBarOverlay"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -118.0
-margin_top = 46.0
-margin_right = -111.0
-margin_bottom = 54.0
-texture = ExtResource( 5 )
-
-[node name="TilesButton" type="TextureButton" parent="UI"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_bottom = 32.0
-grow_horizontal = 0
-grow_vertical = 0
-expand = true
-
-[node name="ObjectsButton" type="TextureButton" parent="UI"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_top = 34.0
-margin_bottom = 66.0
-grow_horizontal = 0
-grow_vertical = 0
-expand = true
-
-[node name="EraserButton" type="TextureRect" parent="UI"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -128.0
-margin_top = 68.0
-margin_right = -96.0
-margin_bottom = 100.0
+[connection signal="pressed" from="UI/SideBar/VBoxContainer/TilesButton" to="." method="_on_TilesButton_pressed"]
+[connection signal="pressed" from="UI/SideBar/VBoxContainer/ObjectsButton" to="." method="_on_ObjectsButton_pressed"]


### PR DESCRIPTION
There were a lot of changes made in this.

The scene tree was overhauled. The overlay section has been removed completely. Text is now part of the buttons. And the white overlay you wanted when clicking a button is now done with the focus style. An object uses the focus style when it's been clicked on and if there is a focus style for that object. Also arrow icons are now the children of their respective buttons.

Here's the code changes
-The margin code for the top and bottom bar has been removed. The scene now uses anchors to keep the bars in the right place and they scale properly.
-All input code has been put under the input event function.
-Fixed an input issue, two inputs were using the same button which caused a bug.
-Removed code relating to category selected.
-Button code is now done with signals.