### PR TITLE
Fix bug in player script and code cleanup

### DIFF
--- a/src/Scenes/BadGuys/Snowball.gd
+++ b/src/Scenes/BadGuys/Snowball.gd
@@ -63,7 +63,7 @@ func _on_Head_area_entered(area):
 		$AnimationPlayer.play("squished")
 		$SFX/Squish.play()
 		var player = area.get_parent()
-		if player.jumpheld > 0:
+		if player.on_ground > 0:
 			player.velocity.y = -player.JUMP_POWER
 			player.jumpcancel = true
 		else:

--- a/src/Scenes/Objects/Fireball.gd
+++ b/src/Scenes/Objects/Fireball.gd
@@ -1,7 +1,7 @@
 extends KinematicBody2D
 
 var velocity = Vector2(0,0)
-var oldvelocity = velocity.x
+var oldvelocity
 var hit = false
 
 func explode():
@@ -30,7 +30,7 @@ func _physics_process(delta):
 			$AnimationPlayer.play("ActiveLeft")
 		velocity.y += 20
 		var collision = move_and_collide(velocity * delta)
-		var oldvelocity = velocity.x
+		oldvelocity = velocity.x
 		if collision:
 			velocity = velocity.bounce(collision.normal)
 			if velocity.x != oldvelocity:


### PR DESCRIPTION

Bug Fix
-Changed `move_and_slide()` so it has a value for `slope_stop_min_velocity`.
-Changed the jump animation so it is called when the player hits jump instead of when the y velocity is greater than 0.
Cleanup
-Remove player code for `jumpheld` variable.
-Update snowball script to use the `on_ground` value instead of `jumpheld`.
-Removed the stop skidding in air code since it was redundant.
-Fixed a variable being declared twice in the fireball script
-The jumping code is now in the `_input(event)` function. This is better for performance.