### PR TITLE
Improve snowball and coin performance with visibility enabler

### DIFF
--- a/src/Scenes/Objects/BadGuys/Snowball.gd
+++ b/src/Scenes/Objects/BadGuys/Snowball.gd
@@ -23,16 +23,6 @@ func _physics_process(_delta):
 	if get_tree().current_scene.editmode == true:
 		return
 	
-	if $VisibilityNotifier2D.is_on_screen() == false:
-		if state != "active": queue_free()
-		else:
-			$AnimatedSprite.visible = false
-			return
-	elif state == "active": $AnimatedSprite.visible = true
-	
-	if get_tree().current_scene.editmode == true:
-		return
-	
 	# Movement
 	if state == "active":
 		velocity.x = -100 * $AnimatedSprite.scale.x
@@ -77,10 +67,6 @@ func _on_Head_area_entered(area):
 		$SFX/Squish.play()
 		player.call("bounce")
 
-# Despawn when falling out of world
-	if position.y > get_tree().current_scene.get_node("Camera2D").limit_bottom:
-		queue_free()
-
 # Hit player
 func _on_snowball_body_entered(body):
 	if body.is_in_group("player"):
@@ -88,3 +74,7 @@ func _on_snowball_body_entered(body):
 	if state == "active" and body.has_method("hurt") and body.invincible_time == 0:
 		body.hurt()
 	return
+
+#Die when knocked off stage
+func _on_VisibilityEnabler2D_screen_exited():
+	if state != "active": queue_free()

--- a/src/Scenes/Objects/BadGuys/Snowball.tscn
+++ b/src/Scenes/Objects/BadGuys/Snowball.tscn
@@ -191,15 +191,17 @@ __meta__ = {
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )
-frame = 4
+frame = 6
 playing = true
 offset = Vector2( 0, -3 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
 
-[node name="VisibilityNotifier2D" type="VisibilityNotifier2D" parent="."]
-rect = Rect2( -25, -25, 50, 50 )
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+position = Vector2( -0.0874104, -0.174824 )
+scale = Vector2( 2.51224, 2.53846 )
+physics_process_parent = true
 
 [node name="Head" type="Area2D" parent="."]
 
@@ -271,5 +273,6 @@ angle_random = 1.0
 scale_amount = 0.1
 scale_amount_random = 0.3
 color_ramp = SubResource( 9 )
+[connection signal="screen_exited" from="VisibilityEnabler2D" to="." method="_on_VisibilityEnabler2D_screen_exited"]
 [connection signal="area_entered" from="Head" to="." method="_on_Head_area_entered"]
 [connection signal="body_entered" from="Area2D" to="." method="_on_snowball_body_entered"]

--- a/src/Scenes/Objects/Bonus/Coin.tscn
+++ b/src/Scenes/Objects/Bonus/Coin.tscn
@@ -122,7 +122,7 @@ script = ExtResource( 1 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 1 )
-frame = 7
+frame = 5
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -164,4 +164,8 @@ color_ramp = SubResource( 4 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 anims/Pickup = SubResource( 5 )
+
+[node name="VisibilityEnabler2D" type="VisibilityEnabler2D" parent="."]
+position = Vector2( -0.174824, -0.0874083 )
+scale = Vector2( 1.6993, 1.69056 )
 [connection signal="body_entered" from="." to="." method="_on_Coin_body_entered"]


### PR DESCRIPTION
I've added a visibility enabler to the coin. This means when it isn't on scene it stops animating.

There were several changes to the nowball
-I also replaced the Snowballs visibility notifier with a visibility enabler. Like the coin it stops it from animating while it's offscreen. I also set this one to pause the physics process function when it's offscreen which should give better performance. 
-checking if something is active when it's offscreen is now done using signals so that should help performance as well. 
-There was also a duplicate line of code I removed.
-I removed the old code for killing the snowball when it falls off screen since the visibilityenabler does it now.

Also I don't think setting things as invisible when they're offscreen improves performance so I left it out.