### PR TITLE
Fix snowball death performance issue

### DIFF
--- a/src/Scenes/Objects/BadGuys/Snowball.gd
+++ b/src/Scenes/Objects/BadGuys/Snowball.gd
@@ -14,9 +14,9 @@ func _ready():
 
 func disable():
 	remove_from_group("badguys")
-	$CollisionShape2D.disabled = true
-	$Head/CollisionShape2D.disabled = true
-	$Area2D/CollisionShape2D.disabled = true
+	$CollisionShape2D.call_deferred("set_disabled", true)
+	$Head/CollisionShape2D.call_deferred("set_disabled", true)
+	$Area2D/CollisionShape2D.call_deferred("set_disabled", true)
 
 # Physics
 func _physics_process(_delta):
@@ -34,7 +34,6 @@ func _physics_process(_delta):
 	
 	# Kill states
 	if state == "kill":
-		disable()
 		velocity = move_and_slide(velocity, Vector2(0,0))
 		velocity.y += 20
 		$AnimatedSprite.rotation_degrees += rotate

--- a/src/Scenes/Player/Objects/Fireball.gd
+++ b/src/Scenes/Player/Objects/Fireball.gd
@@ -6,8 +6,8 @@ var hit = false
 
 func explode():
 	remove_from_group("bullets")
-	$CollisionShape2D.disabled = true
-	$Area2D/EnemyCollision.disabled = true
+	$CollisionShape2D.call_deferred("set_disabled", true)
+	$Area2D/EnemyCollision.call_deferred("set_disabled", true)
 	$AnimationPlayer.play("Hit")
 	hit = true
 


### PR DESCRIPTION
Disabling collision shapes for snowballs is now done with call deferred. Performance when they die is good now and this fixes the errors the debugger was generating. This also fixes the weird behavior that required `disable()` to be called twice so its been removed from the `if state == "kill"` part of the code. Closes #23 

I also set up fireball to use `call_deferred()` so it doesn't create errors anymore.