### PR TITLE
Remove popup nodes

### DIFF
--- a/src/Scenes/Editor/LayerMenu.gd
+++ b/src/Scenes/Editor/LayerMenu.gd
@@ -146,18 +146,18 @@ func _on_DeleteNo_pressed():
 	hide = false
 
 func list_files_in_directory(path):
-    files = []
-    dir = Directory.new()
-    dir.open(path)
-    dir.list_dir_begin()
+	files = []
+	dir = Directory.new()
+	dir.open(path)
+	dir.list_dir_begin()
 
-    while true:
-        var file = dir.get_next()
-        if file == "":
-            break
-        elif not file.begins_with("."):
-            files.append(file)
+	while true:
+		var file = dir.get_next()
+		if file == "":
+			break
+		elif not file.begins_with("."):
+			files.append(file)
 
-    dir.list_dir_end()
+	dir.list_dir_end()
 
-    return files
+	return files

--- a/src/Scenes/Master/Gameplay.gd
+++ b/src/Scenes/Master/Gameplay.gd
@@ -132,7 +132,7 @@ func enter_level_init(level, properties):
 	editmode_toggle()
 	$CanvasLayer/AnimationPlayer.play("Circle In")
 	if properties:
-		UIHelpers.get_editor().get_node("Menu/Settings").popup()
+		UIHelpers.get_editor().get_node("Menu/Settings").show()
 
 func enter_level(level):
 	$CanvasLayer/AnimationPlayer.play("Circle Out")

--- a/src/Scenes/Master/Gameplay.tscn
+++ b/src/Scenes/Master/Gameplay.tscn
@@ -68,8 +68,6 @@ stream = SubResource( 1 )
 [node name="Camera2D" type="Camera2D" parent="."]
 pause_mode = 2
 current = true
-drag_margin_h_enabled = false
-drag_margin_v_enabled = false
 smoothing_speed = 15.0
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]

--- a/src/Scenes/Objects/Map/LevelDot.gd
+++ b/src/Scenes/Objects/Map/LevelDot.gd
@@ -55,15 +55,15 @@ func _on_Load_pressed():
 		if UIHelpers._get_scene().check_level_valid(selectdir) == true:
 			level = selectdir
 			$DisplayName.text = load(str(level)).instance().level_name
-			$CanvasLayer/Popup.popup()
+			$CanvasLayer/Popup.show()
 		else:
-			$CanvasLayer/Error.popup()
+			$CanvasLayer/Error.show()
 
 	# Otherwise don't do anything
 	else:
-		$CanvasLayer/Popup.popup()
+		$CanvasLayer/Popup.show()
 	$CanvasLayer/BottomName.text = $DisplayName.text
 
 func _on_ErrorButton_pressed():
 	$CanvasLayer/Error.hide()
-	$CanvasLayer/Popup.popup()
+	$CanvasLayer/Popup.show()

--- a/src/Scenes/Objects/Map/LevelDot.tscn
+++ b/src/Scenes/Objects/Map/LevelDot.tscn
@@ -45,16 +45,16 @@ extra_spacing_top = 2
 font_data = ExtResource( 4 )
 
 [node name="LevelDot" type="Node2D" groups=[
-"popup",
 "leveldot",
+"popup",
 ]]
 script = ExtResource( 1 )
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 layer = 6
 
-[node name="Popup" type="Popup" parent="CanvasLayer"]
-visible = true
+[node name="Popup" type="Control" parent="CanvasLayer"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -79,7 +79,7 @@ margin_bottom = -38.0
 
 [node name="Label" type="Label" parent="CanvasLayer/Popup/Panel/VBoxContainer"]
 margin_right = 214.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 custom_colors/font_color = Color( 0, 1, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
@@ -89,33 +89,33 @@ align = 1
 valign = 1
 
 [node name="Line2" type="TextureRect" parent="CanvasLayer/Popup/Panel/VBoxContainer"]
-margin_top = 24.0
+margin_top = 25.0
 margin_right = 214.0
-margin_bottom = 26.0
+margin_bottom = 27.0
 rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 3 )
 expand = true
 
 [node name="Load" type="Button" parent="CanvasLayer/Popup/Panel/VBoxContainer"]
-margin_top = 30.0
+margin_top = 31.0
 margin_right = 214.0
-margin_bottom = 50.0
+margin_bottom = 52.0
 focus_mode = 1
 action_mode = 0
 enabled_focus_mode = 1
 text = "Level to load"
 
 [node name="Invisible" type="HBoxContainer" parent="CanvasLayer/Popup/Panel/VBoxContainer"]
-margin_top = 54.0
+margin_top = 56.0
 margin_right = 214.0
-margin_bottom = 74.0
+margin_bottom = 77.0
 custom_constants/separation = 16
 alignment = 1
 
 [node name="Label" type="Label" parent="CanvasLayer/Popup/Panel/VBoxContainer/Invisible"]
 margin_left = 42.0
 margin_right = 139.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
@@ -124,23 +124,23 @@ text = "Invisible"
 [node name="CheckBox" type="CheckBox" parent="CanvasLayer/Popup/Panel/VBoxContainer/Invisible"]
 margin_left = 155.0
 margin_right = 171.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 focus_mode = 1
 action_mode = 0
 enabled_focus_mode = 1
 align = 1
 
 [node name="AutoPlay" type="HBoxContainer" parent="CanvasLayer/Popup/Panel/VBoxContainer"]
-margin_top = 78.0
+margin_top = 81.0
 margin_right = 214.0
-margin_bottom = 98.0
+margin_bottom = 102.0
 custom_constants/separation = 16
 alignment = 1
 
 [node name="Label" type="Label" parent="CanvasLayer/Popup/Panel/VBoxContainer/AutoPlay"]
 margin_left = 34.0
 margin_right = 148.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
@@ -149,7 +149,7 @@ text = "Auto play"
 [node name="CheckBox" type="CheckBox" parent="CanvasLayer/Popup/Panel/VBoxContainer/AutoPlay"]
 margin_left = 164.0
 margin_right = 180.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 focus_mode = 1
 action_mode = 0
 enabled_focus_mode = 1
@@ -174,8 +174,8 @@ rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 3 )
 expand = true
 
-[node name="Error" type="Popup" parent="CanvasLayer"]
-editor/display_folded = true
+[node name="Error" type="Control" parent="CanvasLayer"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5

--- a/src/Scenes/UI/FileSelect.gd
+++ b/src/Scenes/UI/FileSelect.gd
@@ -12,7 +12,7 @@ var filetype = ""
 func _ready():
 	$Popup/Panel/VBoxContainer/FileName.visible = save
 	$Popup/Panel/VBoxContainer/FileName/HSplitContainer/FileType.text = filetype
-	$Popup.popup()
+	$Popup.show()
 	reload()
 
 func _process(delta):
@@ -73,7 +73,7 @@ func _on_OK_pressed():
 	var files = list_files_in_directory(directory)
 	if save and (selectedfile != null or (str(savename, filetype) in files)):
 		$Popup.hide()
-		$Overwrite.popup()
+		$Overwrite.show()
 	else:
 		cancel = false
 		queue_free()
@@ -107,4 +107,4 @@ func _on_OverwriteYes_pressed():
 
 func _on_OverwriteNo_pressed():
 	$Overwrite.hide()
-	$Popup.popup()
+	$Popup.show()

--- a/src/Scenes/UI/FileSelect.tscn
+++ b/src/Scenes/UI/FileSelect.tscn
@@ -31,8 +31,8 @@ font_data = ExtResource( 5 )
 layer = 8
 script = ExtResource( 1 )
 
-[node name="Overwrite" type="Popup" parent="."]
-editor/display_folded = true
+[node name="Overwrite" type="Control" parent="."]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -42,7 +42,6 @@ margin_top = -47.5
 margin_right = 150.0
 margin_bottom = 47.5
 theme = ExtResource( 2 )
-popup_exclusive = true
 
 [node name="Panel" type="Panel" parent="Overwrite"]
 anchor_right = 1.0
@@ -61,7 +60,7 @@ alignment = 1
 [node name="Label" type="Label" parent="Overwrite/Panel/VBoxContainer"]
 margin_top = 2.0
 margin_right = 284.0
-margin_bottom = 22.0
+margin_bottom = 23.0
 custom_colors/font_color = Color( 1, 0, 0, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
@@ -70,18 +69,17 @@ text = "Overwrite the file?"
 align = 1
 
 [node name="Line" type="TextureRect" parent="Overwrite/Panel/VBoxContainer"]
-margin_top = 32.0
+margin_top = 33.0
 margin_right = 284.0
-margin_bottom = 34.0
+margin_bottom = 35.0
 rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 3 )
 expand = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Overwrite/Panel/VBoxContainer"]
-editor/display_folded = true
-margin_top = 44.0
+margin_top = 45.0
 margin_right = 284.0
-margin_bottom = 76.0
+margin_bottom = 77.0
 rect_min_size = Vector2( 0, 32 )
 custom_constants/separation = 80
 alignment = 1
@@ -104,8 +102,8 @@ focus_mode = 0
 enabled_focus_mode = 0
 text = "Cancel"
 
-[node name="Popup" type="Popup" parent="."]
-visible = true
+[node name="Popup" type="Control" parent="."]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -115,7 +113,6 @@ margin_top = -180.0
 margin_right = 200.0
 margin_bottom = 180.0
 theme = ExtResource( 2 )
-popup_exclusive = true
 
 [node name="Panel" type="Panel" parent="Popup"]
 anchor_right = 1.0
@@ -186,7 +183,6 @@ texture = ExtResource( 3 )
 expand = true
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Popup/Panel/VBoxContainer"]
-editor/display_folded = true
 margin_top = 40.0
 margin_right = 384.0
 margin_bottom = 274.0
@@ -222,7 +218,7 @@ margin_bottom = 35.0
 rect_min_size = Vector2( 0, 32 )
 
 [node name="Label" type="Label" parent="Popup/Panel/VBoxContainer/FileName/HSplitContainer"]
-margin_top = 6.0
+margin_top = 5.0
 margin_right = 65.0
 margin_bottom = 26.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -239,7 +235,7 @@ context_menu_enabled = false
 
 [node name="FileType" type="Label" parent="Popup/Panel/VBoxContainer/FileName/HSplitContainer"]
 margin_left = 346.0
-margin_top = 6.0
+margin_top = 5.0
 margin_right = 384.0
 margin_bottom = 26.0
 custom_fonts/font = SubResource( 2 )

--- a/src/Scenes/UI/LevelEditor.gd
+++ b/src/Scenes/UI/LevelEditor.gd
@@ -113,7 +113,7 @@ func _process(_delta):
 		if $Menu/Editor.visible:
 			$Menu/Editor.hide()
 		else:
-			$Menu/Editor.popup()
+			$Menu/Editor.show()
 
 	if $Menu/Editor.visible or $Menu/Create.visible or $Menu/Settings.visible or $Menu/Exit.visible or $UI/AddLayer.visible:
 		$SelectedTile.visible = false
@@ -209,7 +209,7 @@ func _process(_delta):
 							dragpos = Vector2(0,0)
 							return
 						if Input.is_action_just_pressed("click_right") and child.is_in_group("popup"):
-							child.get_node("CanvasLayer/Popup").popup()
+							child.get_node("CanvasLayer/Popup").show()
 							clickdisable = true
 
 	# If clicking on an expandable area, drag it
@@ -220,7 +220,7 @@ func _process(_delta):
 					$SelectedTile.visible = false
 					object_hovered = true
 					if Input.is_action_just_pressed("click_right") and child.is_in_group("popup"):
-						child.get_node("CanvasLayer/Popup").popup()
+						child.get_node("CanvasLayer/Popup").show()
 						clickdisable = true
 					elif Input.is_action_just_pressed("click_left"):
 						dragging_object = true
@@ -635,7 +635,7 @@ func _on_LayerAdd_button_down():
 			item.erase(item.length() - 5,5)
 			$UI/AddLayer/VBoxContainer/OptionButton.add_icon_item(load(str("res://Sprites/Editor/LayerIcons/", item, ".png")),item)
 
-	$UI/AddLayer.popup()
+	$UI/AddLayer.show()
 	$UI/AddLayer/VBoxContainer/OptionButton.selected = tilemappos
 
 func _on_AddLayer_popup_hide():
@@ -738,7 +738,7 @@ func _on_Play_pressed():
 
 func _on_SettingsConfirmation_pressed():
 	$Menu/Settings.hide()
-	$Menu/Editor.popup()
+	$Menu/Editor.show()
 
 func _on_Yes_pressed():
 	UIHelpers._get_scene().save_level()
@@ -757,7 +757,7 @@ func _on_No_pressed():
 
 func _on_Cancel_pressed():
 	$Menu/Settings.hide()
-	$Menu/Editor.popup()
+	$Menu/Editor.show()
 
 func _on_LevelSave_pressed():
 	if UIHelpers._get_scene().current_level != "user://Scenes/Levels/EditedLevel/EditedLevel.tscn":
@@ -766,13 +766,13 @@ func _on_LevelSave_pressed():
 		$Menu/Editor.hide()
 		UIHelpers._get_scene().save_level_as()
 		yield(UIHelpers._get_scene().get_node("FileSelect"), "tree_exiting")
-		$Menu/Editor.popup()
+		$Menu/Editor.show()
 
 func _on_LevelSaveAs_pressed():
 	$Menu/Editor.hide()
 	UIHelpers._get_scene().save_level_as()
 	yield(UIHelpers._get_scene().get_node("FileSelect"), "tree_exiting")
-	$Menu/Editor.popup()
+	$Menu/Editor.show()
 
 func _on_LevelOpen_pressed():
 	$Menu/Editor.hide()
@@ -784,12 +784,12 @@ func _on_LevelOpen_pressed():
 
 func _on_LevelProperties_pressed():
 	$Menu/Editor.hide()
-	$Menu/Settings.popup()
+	$Menu/Settings.show()
 
 func _on_ReturnMenu_pressed():
 	$Menu/Editor.hide()
 	if UIHelpers.get_level() != null:
-		$Menu/Exit.popup()
+		$Menu/Exit.show()
 	else:
 		get_tree().change_scene("res://Scenes/UI/MainMenu.tscn")
 
@@ -798,7 +798,7 @@ func _on_Return_pressed():
 
 func _on_LevelCreate_pressed():
 	$Menu/Editor.hide()
-	$Menu/Create.popup()
+	$Menu/Create.show()
 
 func _on_CreateLevel_pressed():
 	create_level("res://Scenes/Editor/LevelTemplates/Level.tscn")
@@ -822,7 +822,7 @@ func create_level(level):
 
 func _on_CancelCreation_pressed():
 	$Menu/Create.hide()
-	$Menu/Editor.popup()
+	$Menu/Editor.show()
 
 func _on_Save_pressed():
 	if UIHelpers._get_scene().current_level != "user://Scenes/Levels/EditedLevel/EditedLevel.tscn":
@@ -832,7 +832,7 @@ func _on_Save_pressed():
 		yield(UIHelpers._get_scene().get_node("FileSelect"), "tree_exiting")
 
 func initial_menu():
-	$Menu/Editor.popup()
+	$Menu/Editor.show()
 	$Menu/Editor/Panel/VBoxContainer/Return.hide()
 	$Menu/Editor/Panel/VBoxContainer/LevelSave.hide()
 	$Menu/Editor/Panel/VBoxContainer/LevelSaveAs.hide()
@@ -851,4 +851,4 @@ func _on_MusicSelect_pressed():
 	if UIHelpers._get_scene().get_node("FileSelect").cancel == false:
 		UIHelpers.get_level().music = UIHelpers._get_scene().get_node("FileSelect").selectdir
 		$Menu/Settings/Panel/VBoxContainer/Music/MusicSelect.text = UIHelpers.get_level().music
-	$Menu/Settings.popup()
+	$Menu/Settings.show()

--- a/src/Scenes/UI/LevelEditor.tscn
+++ b/src/Scenes/UI/LevelEditor.tscn
@@ -397,7 +397,6 @@ anims/MoveIn = SubResource( 1 )
 anims/MoveOut = SubResource( 2 )
 
 [node name="SideBar" type="ColorRect" parent="UI"]
-editor/display_folded = true
 anchor_left = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -410,7 +409,6 @@ anchor_bottom = 1.0
 custom_constants/separation = 0
 
 [node name="TilesButton" type="Button" parent="UI/SideBar/VBoxContainer"]
-editor/display_folded = true
 margin_right = 128.0
 margin_bottom = 32.0
 grow_horizontal = 0
@@ -459,7 +457,6 @@ margin_bottom = 34.0
 texture = ExtResource( 9 )
 
 [node name="ObjectsButton" type="Button" parent="UI/SideBar/VBoxContainer"]
-editor/display_folded = true
 margin_top = 34.0
 margin_right = 128.0
 margin_bottom = 66.0
@@ -509,7 +506,6 @@ margin_bottom = 68.0
 texture = ExtResource( 9 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="UI/SideBar/VBoxContainer"]
-editor/display_folded = true
 margin_top = 68.0
 margin_right = 128.0
 margin_bottom = 100.0
@@ -589,7 +585,6 @@ margin_top = -64.0
 color = Color( 0.25098, 0.25098, 0.25098, 0.74902 )
 
 [node name="ScrollContainer" type="ScrollContainer" parent="UI/BottomBar"]
-editor/display_folded = true
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -757,8 +752,8 @@ texture = ExtResource( 14 )
 expand = true
 stretch_mode = 6
 
-[node name="AddLayer" type="Popup" parent="UI"]
-visible = true
+[node name="AddLayer" type="Control" parent="UI"]
+visible = false
 anchor_bottom = 1.0
 margin_left = 2.0
 margin_top = 2.0
@@ -781,7 +776,7 @@ rect_clip_content = true
 
 [node name="Label" type="Label" parent="UI/AddLayer/VBoxContainer"]
 margin_right = 238.0
-margin_bottom = 20.0
+margin_bottom = 21.0
 custom_colors/font_color = Color( 0, 1, 1, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
@@ -790,21 +785,21 @@ text = "Add layer"
 align = 1
 
 [node name="Line" type="TextureRect" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 24.0
+margin_top = 25.0
 margin_right = 238.0
-margin_bottom = 26.0
+margin_bottom = 27.0
 rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 9 )
 expand = true
 
 [node name="Name" type="HSplitContainer" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 30.0
+margin_top = 31.0
 margin_right = 238.0
-margin_bottom = 62.0
+margin_bottom = 63.0
 rect_min_size = Vector2( 0, 32 )
 
 [node name="Label2" type="Label" parent="UI/AddLayer/VBoxContainer/Name"]
-margin_top = 6.0
+margin_top = 5.0
 margin_right = 65.0
 margin_bottom = 26.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -821,21 +816,21 @@ rect_min_size = Vector2( 140, 0 )
 text = "Layer"
 
 [node name="Line3" type="TextureRect" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 66.0
+margin_top = 67.0
 margin_right = 238.0
-margin_bottom = 68.0
+margin_bottom = 69.0
 rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 9 )
 expand = true
 
 [node name="Zaxis" type="HSplitContainer" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 72.0
+margin_top = 73.0
 margin_right = 238.0
-margin_bottom = 104.0
+margin_bottom = 105.0
 rect_min_size = Vector2( 0, 32 )
 
 [node name="Label2" type="Label" parent="UI/AddLayer/VBoxContainer/Zaxis"]
-margin_top = 6.0
+margin_top = 5.0
 margin_right = 78.0
 margin_bottom = 26.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -854,17 +849,17 @@ rounded = true
 align = 2
 
 [node name="Line2" type="TextureRect" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 108.0
+margin_top = 109.0
 margin_right = 238.0
-margin_bottom = 110.0
+margin_bottom = 111.0
 rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 9 )
 expand = true
 
 [node name="Label3" type="Label" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 114.0
+margin_top = 115.0
 margin_right = 238.0
-margin_bottom = 134.0
+margin_bottom = 136.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
@@ -872,9 +867,9 @@ text = "Layer type:"
 align = 1
 
 [node name="OptionButton" type="OptionButton" parent="UI/AddLayer/VBoxContainer"]
-margin_top = 138.0
+margin_top = 140.0
 margin_right = 238.0
-margin_bottom = 158.0
+margin_bottom = 161.0
 
 [node name="Line" type="TextureRect" parent="UI/AddLayer"]
 anchor_top = 1.0
@@ -913,7 +908,6 @@ size_flags_horizontal = 3
 text = "Cancel"
 
 [node name="Play" type="CanvasLayer" parent="."]
-editor/display_folded = true
 layer = 3
 
 [node name="Play" type="Button" parent="Play"]
@@ -956,7 +950,6 @@ margin_bottom = 56.0
 texture = ExtResource( 16 )
 
 [node name="GrabArea" type="CanvasLayer" parent="."]
-editor/display_folded = true
 layer = 2
 
 [node name="C1" type="TextureButton" parent="GrabArea"]
@@ -1020,8 +1013,8 @@ expand = true
 [node name="Menu" type="CanvasLayer" parent="."]
 layer = 4
 
-[node name="Editor" type="Popup" parent="Menu"]
-editor/display_folded = true
+[node name="Editor" type="Control" parent="Menu"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1031,7 +1024,6 @@ margin_top = -163.0
 margin_right = 179.0
 margin_bottom = 163.0
 theme = ExtResource( 7 )
-popup_exclusive = true
 
 [node name="Panel" type="Panel" parent="Menu/Editor"]
 anchor_right = 1.0
@@ -1123,8 +1115,8 @@ focus_mode = 1
 size_flags_vertical = 3
 text = "Exit to Menu"
 
-[node name="Settings" type="Popup" parent="Menu"]
-visible = true
+[node name="Settings" type="Control" parent="Menu"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1175,7 +1167,7 @@ rect_min_size = Vector2( 0, 32 )
 size_flags_vertical = 3
 
 [node name="Label" type="Label" parent="Menu/Settings/Panel/VBoxContainer/Name"]
-margin_top = 7.0
+margin_top = 6.0
 margin_right = 136.0
 margin_bottom = 27.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -1191,7 +1183,6 @@ text = "SuperTux Level"
 align = 2
 
 [node name="Creator" type="HSplitContainer" parent="Menu/Settings/Panel/VBoxContainer"]
-editor/display_folded = true
 margin_top = 80.0
 margin_right = 458.0
 margin_bottom = 114.0
@@ -1199,7 +1190,7 @@ rect_min_size = Vector2( 0, 32 )
 size_flags_vertical = 3
 
 [node name="Label" type="Label" parent="Menu/Settings/Panel/VBoxContainer/Creator"]
-margin_top = 7.0
+margin_top = 6.0
 margin_right = 169.0
 margin_bottom = 27.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -1222,7 +1213,7 @@ rect_min_size = Vector2( 0, 32 )
 size_flags_vertical = 3
 
 [node name="Label2" type="Label" parent="Menu/Settings/Panel/VBoxContainer/Music"]
-margin_top = 7.0
+margin_top = 6.0
 margin_right = 137.0
 margin_bottom = 27.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
@@ -1241,7 +1232,6 @@ text = "No Music Set"
 clip_text = true
 
 [node name="SettingsConfirmation" type="Button" parent="Menu/Settings/Panel"]
-editor/display_folded = true
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -1258,8 +1248,8 @@ rect_min_size = Vector2( 0, 2 )
 texture = ExtResource( 9 )
 expand = true
 
-[node name="Create" type="Popup" parent="Menu"]
-editor/display_folded = true
+[node name="Create" type="Control" parent="Menu"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1269,7 +1259,6 @@ margin_top = -87.0
 margin_right = 179.0
 margin_bottom = 87.0
 theme = ExtResource( 7 )
-popup_exclusive = true
 
 [node name="Panel" type="Panel" parent="Menu/Create"]
 anchor_right = 1.0
@@ -1338,8 +1327,8 @@ size_flags_vertical = 3
 enabled_focus_mode = 1
 text = "Cancel"
 
-[node name="Exit" type="Popup" parent="Menu"]
-editor/display_folded = true
+[node name="Exit" type="Control" parent="Menu"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -1366,7 +1355,6 @@ texture = ExtResource( 9 )
 expand = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Menu/Exit/Panel"]
-editor/display_folded = true
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 8.0
@@ -1435,7 +1423,6 @@ text = "Cancel"
 [connection signal="pressed" from="UI/BottomBar/Zoom/ZoomDefault" to="." method="_on_ZoomDefault_pressed"]
 [connection signal="pressed" from="UI/BottomBar/Zoom/ZoomOut" to="." method="_on_ZoomOut_pressed"]
 [connection signal="pressed" from="UI/BottomBar/Save" to="." method="_on_Save_pressed"]
-[connection signal="popup_hide" from="UI/AddLayer" to="." method="_on_AddLayer_popup_hide"]
 [connection signal="pressed" from="UI/AddLayer/HBoxContainer/LayerConfirmation" to="." method="_on_LayerConfirmation_pressed"]
 [connection signal="pressed" from="UI/AddLayer/HBoxContainer/LayerCancel" to="." method="_on_LayerCancel_pressed"]
 [connection signal="pressed" from="Play/Play" to="." method="_on_Play_pressed"]

--- a/src/Scenes/UI/LevelUI.tscn
+++ b/src/Scenes/UI/LevelUI.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://Fonts/SuperTux-Medium.ttf" type="DynamicFontData" id=3]
 [ext_resource path="res://Sprites/Objects/Coin/coin-0.png" type="Texture" id=4]
 
-[sub_resource type="DynamicFont" id=2]
+[sub_resource type="DynamicFont" id=1]
 size = 25
 outline_size = 1
 outline_color = Color( 0, 0, 0, 1 )
@@ -13,7 +13,7 @@ use_filter = true
 extra_spacing_bottom = 11
 font_data = ExtResource( 3 )
 
-[sub_resource type="DynamicFont" id=3]
+[sub_resource type="DynamicFont" id=2]
 size = 15
 outline_size = 1
 outline_color = Color( 0, 0, 0, 1 )
@@ -26,7 +26,6 @@ font_data = ExtResource( 3 )
 script = ExtResource( 1 )
 
 [node name="PauseMenu" parent="." instance=ExtResource( 2 )]
-margin_bottom = 105.0
 
 [node name="CoinCounter" type="Control" parent="."]
 anchor_left = 1.0
@@ -35,7 +34,6 @@ margin_left = 100.0
 margin_right = 100.0
 
 [node name="CoinCount" type="Label" parent="CoinCounter"]
-editor/display_folded = true
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0
@@ -48,7 +46,7 @@ grow_horizontal = 0
 rect_scale = Vector2( 0.75, 0.75 )
 size_flags_horizontal = 0
 size_flags_stretch_ratio = 0.0
-custom_fonts/font = SubResource( 2 )
+custom_fonts/font = SubResource( 1 )
 custom_colors/font_color = Color( 0.87451, 0.898039, 0.164706, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 3
@@ -61,7 +59,7 @@ margin_left = -15.3333
 margin_top = 5.0
 margin_right = -4.33331
 margin_bottom = 21.0
-custom_fonts/font = SubResource( 3 )
+custom_fonts/font = SubResource( 2 )
 custom_colors/font_color = Color( 0.87451, 0.898039, 0.164706, 1 )
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 2
@@ -76,3 +74,6 @@ margin_bottom = 29.0
 texture = ExtResource( 4 )
 expand = true
 stretch_mode = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/src/Scenes/UI/MainMenu.tscn
+++ b/src/Scenes/UI/MainMenu.tscn
@@ -88,7 +88,8 @@ margin_right = 90.0
 margin_bottom = 150.0
 theme = ExtResource( 4 )
 __meta__ = {
-"_edit_group_": true
+"_edit_group_": true,
+"_edit_use_anchors_": false
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
@@ -160,4 +161,3 @@ autoplay = true
 [connection signal="pressed" from="Panel/VBoxContainer/Options" to="." method="_on_Options_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/Credits" to="." method="_on_Credits_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/Quit" to="." method="_on_Quit_pressed"]
-[connection signal="popup_hide" from="Options" to="." method="_on_Options_popup_hide"]

--- a/src/Scenes/UI/Options.gd
+++ b/src/Scenes/UI/Options.gd
@@ -1,4 +1,4 @@
-extends Popup
+extends Control
 
 func _ready():
 	$VBoxContainer/HBoxContainer/FullscreenCheck.pressed = Settings.config.get_value("video", "fullscreen", false)

--- a/src/Scenes/UI/Options.tscn
+++ b/src/Scenes/UI/Options.tscn
@@ -4,7 +4,8 @@
 [ext_resource path="res://Scenes/UI/Options.gd" type="Script" id=2]
 [ext_resource path="res://Sprites/Editor/Line.png" type="Texture" id=3]
 
-[node name="Options" type="Popup"]
+[node name="Options" type="Control"]
+visible = false
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -51,7 +52,6 @@ texture = ExtResource( 3 )
 expand = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
-editor/display_folded = true
 margin_top = 41.0
 margin_right = 164.0
 margin_bottom = 64.0
@@ -62,7 +62,7 @@ alignment = 1
 margin_left = 12.0
 margin_top = 1.0
 margin_right = 132.0
-margin_bottom = 21.0
+margin_bottom = 22.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 0
@@ -75,7 +75,6 @@ margin_bottom = 23.0
 action_mode = 0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
-editor/display_folded = true
 margin_top = 69.0
 margin_right = 164.0
 margin_bottom = 92.0
@@ -86,7 +85,7 @@ alignment = 1
 margin_left = 31.0
 margin_top = 1.0
 margin_right = 112.0
-margin_bottom = 21.0
+margin_bottom = 22.0
 custom_colors/font_color_shadow = Color( 0, 0, 0, 1 )
 custom_constants/shadow_offset_x = 0
 custom_constants/shadow_offset_y = 0

--- a/src/Scenes/UI/PauseMenu.gd
+++ b/src/Scenes/UI/PauseMenu.gd
@@ -1,4 +1,4 @@
-extends Popup
+extends Control
 
 var background_opacity = 0
 var panel_sizemult = 1

--- a/src/Scenes/UI/PauseMenu.tscn
+++ b/src/Scenes/UI/PauseMenu.tscn
@@ -13,8 +13,9 @@ outline_color = Color( 0, 0, 0, 1 )
 use_filter = true
 font_data = ExtResource( 3 )
 
-[node name="PauseMenu" type="Popup"]
+[node name="PauseMenu" type="Control"]
 pause_mode = 2
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 focus_mode = 2
@@ -123,4 +124,3 @@ text = "Quit to Menu"
 [connection signal="pressed" from="Panel/VBoxContainer/Options" to="." method="_on_Options_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/ExitLevel" to="." method="_on_QuitLevel_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/Quit" to="." method="_on_MainMenu_pressed"]
-[connection signal="popup_hide" from="Options" to="." method="_on_Options_popup_hide"]

--- a/src/Tilesets/LevelTiles.tres
+++ b/src/Tilesets/LevelTiles.tres
@@ -164,6 +164,11 @@ points = PoolVector2Array( 0, 0, 32, 0, 32, 32, 0, 32 )
 0/autotile/z_index_map = [  ]
 0/occluder_offset = Vector2( 0, 0 )
 0/navigation_offset = Vector2( 0, 0 )
+0/shape_offset = Vector2( 0, 0 )
+0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+0/shape = SubResource( 1 )
+0/shape_one_way = false
+0/shape_one_way_margin = 1.0
 0/shapes = [ {
 "autotile_coord": Vector2( 0, 0 ),
 "one_way": false,


### PR DESCRIPTION
Replace all popup nodes with control nodes. Popup nodes currently cause issues when scaling the screen. Screen scaling isn't fixed yet there's still more to do.